### PR TITLE
added wf and dcompose

### DIFF
--- a/.github/workflows/deploy-bot-on-stage.yml
+++ b/.github/workflows/deploy-bot-on-stage.yml
@@ -1,0 +1,34 @@
+on:
+  workflow_run:
+    workflows: [Create and publish a Docker image]
+    types: [completed]
+    branches: [develop]
+
+jobs:
+  on-success:
+    runs-on: ubuntu-latest
+    environment:
+      name: stage_deploy
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: ssh pull and start
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.VM_HOST }}
+          username: ${{ secrets.VM_USER }}
+          password: ${{ secrets.VM_PASSWORD }}
+          script: |
+            cd /home/deploy/spread_wings_bot/infra/dev/
+            git pull
+            rm .env
+            touch .env
+            echo DB_URL=${{ secrets.DB_URL }} >> .env
+            echo DEFAULT_EMAIL_ADDRESS=${{ secrets.DEFAULT_EMAIL_ADDRESS }} >> .env
+            echo EMAIL_ACCOUNT=${{ secrets.EMAIL_ACCOUNT }} >> .env
+            echo EMAIL_HOST=${{ secrets.EMAIL_HOST }} >> .env
+            echo EMAIL_PASSWORD=${{ secrets.EMAIL_PASSWORD }} >> .env
+            echo EMAIL_PORT=${{ secrets.EMAIL_PORT }} >> .env
+            echo TELEGRAM_TOKEN=${{ secrets.TELEGRAM_TOKEN }} >> .env
+            sudo docker-compose -f docker-compose.stage.yaml stop
+            sudo docker-compose -f docker-compose.stage.yaml pull
+            sudo docker-compose -f docker-compose.stage.yaml up -d

--- a/infra/dev/docker-compose.stage.yaml
+++ b/infra/dev/docker-compose.stage.yaml
@@ -1,0 +1,8 @@
+version: '3.3'
+services:
+
+  bot:
+    image: "ghcr.io/studio-yandex-practicum/spread_wings_bot:develop"
+    restart: always
+    env_file:
+      - ./.env


### PR DESCRIPTION
- написал воркфлоу, которая ожидает успешное завершение ранее имевшейся работы по сборке образа, после чего тянет репу на ВМ, формирует файл окружения из секретов окружения репозитория,  запускает контейнеры из докер-композа в infra/dev (чтобы изменения в деплое можно было заливать через репозиторий)
- отредактировал докер-композ конфиг в infra/dev чтобы тянуть образ бота из github packages с тегом develop

в процессе создан отдельный пользователь на ВМ по деплой, в репу добавлен его деплой-ключ, а так же секреты для аутентификации. в перспективе хорошо бы чтобы кто-то шаристый этому юзеру настроил на ВМ права только на те действия, для которых он предназначен


олсо, таска тестировалась только по-компонентно