### PR TITLE
changed service handler, added back keyboard

### DIFF
--- a/src/bot/bot.py
+++ b/src/bot/bot.py
@@ -38,10 +38,7 @@ from bot.handlers.assistance import (
 )
 from bot.handlers.back_handler import back_button
 from bot.handlers.main_handlers import help_handler, start_handler
-from bot.handlers.service_handlers import (
-    answer_all_messages_handler,
-    back_button_handler,
-)
+from bot.handlers.service_handlers import answer_all_messages_handler
 from bot.persistence import RedisPersistence
 
 logger = logging.getLogger("bot")
@@ -243,7 +240,6 @@ def build_app() -> Application:
             main_handler,
             help_handler,
             answer_all_messages_handler,
-            back_button_handler,
         ]
     )
     return app

--- a/src/bot/bot.py
+++ b/src/bot/bot.py
@@ -38,7 +38,10 @@ from bot.handlers.assistance import (
 )
 from bot.handlers.back_handler import back_button
 from bot.handlers.main_handlers import help_handler, start_handler
-from bot.handlers.service_handlers import answer_all_messages_handler
+from bot.handlers.service_handlers import (
+    answer_all_messages_handler,
+    back_button_handler,
+)
 from bot.persistence import RedisPersistence
 
 logger = logging.getLogger("bot")
@@ -235,5 +238,12 @@ def build_app() -> Application:
         .persistence(persistence)
         .build()
     )
-    app.add_handlers([main_handler, help_handler, answer_all_messages_handler])
+    app.add_handlers(
+        [
+            main_handler,
+            help_handler,
+            answer_all_messages_handler,
+            back_button_handler,
+        ]
+    )
     return app

--- a/src/bot/handlers/service_handlers.py
+++ b/src/bot/handlers/service_handlers.py
@@ -1,15 +1,56 @@
 from telegram import Update
-from telegram.ext import ContextTypes, MessageHandler, filters
+from telegram.ext import (
+    CallbackQueryHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
 
 from bot.constants.messages import ANSWER_TO_USER_MESSAGE
+from bot.handlers.back_handler import back_button
+from bot.keyboards.get_back import get_back_keyboard
 
 
 async def answer_all_messages(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> None:
-    """Обрабатывает и отвечает на любое введенное пользователем сообщение."""
+    """Удаление и ответ на любое сообщение пользователя."""
+    # Удаляем сообщение пользователя
     await update.message.delete()
-    await update.message.reply_text(ANSWER_TO_USER_MESSAGE)
+
+    # Достаем последний ID сообщения бота
+    user_message_id = update.message.message_id
+    bot_last_message_id = user_message_id - 1
+
+    # Если последний ID доступен, пробуем изменить сообщение
+    if bot_last_message_id:
+        try:
+            await context.bot.edit_message_text(
+                ANSWER_TO_USER_MESSAGE,
+                chat_id=update.effective_chat.id,
+                message_id=bot_last_message_id,
+                reply_markup=get_back_keyboard(),
+            )
+        except Exception as e:
+            # Если изменение не получилось, выдаем ошибку
+            print(f"Failed to edit message: {e}")
+
+    # Если сообщение от бота не найдено или его нет, пишем новое сообщение с текстом и инлайном
+    if not bot_last_message_id:
+        await context.bot.send_message(
+            chat_id=update.effective_chat.id,
+            text=ANSWER_TO_USER_MESSAGE,
+            reply_markup=get_back_keyboard(),
+        )
+
+    # Обновляем последнее сообщение с ID = сообщению бота
+    context.user_data["last_bot_message_id"] = bot_last_message_id
+
+    await back_button(update, context)
 
 
+# Определяем хендлер ответа на сообщения пользователя
 answer_all_messages_handler = MessageHandler(filters.ALL, answer_all_messages)
+
+# Определяем хендлер кнопки назад
+back_button_handler = CallbackQueryHandler(back_button, pattern=r"^back$")

--- a/src/bot/handlers/service_handlers.py
+++ b/src/bot/handlers/service_handlers.py
@@ -16,9 +16,7 @@ async def answer_all_messages(
     await update.message.delete()
 
     user_message_id = update.message.message_id
-    print(user_message_id)
     bot_last_message_id = user_message_id - 1
-    print(bot_last_message_id)
 
     if bot_last_message_id:
         try:

--- a/src/bot/handlers/service_handlers.py
+++ b/src/bot/handlers/service_handlers.py
@@ -1,7 +1,6 @@
 import logging
 
 from telegram import Update
-from telegram.error import TelegramError
 from telegram.ext import ContextTypes, MessageHandler, filters
 
 from bot.constants.messages import ANSWER_TO_USER_MESSAGE
@@ -14,26 +13,27 @@ async def answer_all_messages(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> None:
     """Удаление и ответ на любое сообщение пользователя."""
-    # Удаляем сообщение пользователя
     await update.message.delete()
 
-    # Достаем последний ID сообщения бота
     user_message_id = update.message.message_id
+    print(user_message_id)
     bot_last_message_id = user_message_id - 1
+    print(bot_last_message_id)
 
-    try:
-        message = await context.bot.edit_message_text(
-            text=ANSWER_TO_USER_MESSAGE,
-            chat_id=update.effective_chat.id,
-            message_id=bot_last_message_id,
-            reply_markup=get_back_keyboard(),
-        )
-    except TelegramError as error:
-        logger.error("Error while editing message: %s", error)
-    else:
-        # Обновляем последнее сообщение с ID = сообщению бота
-        context.user_data["last_bot_message_id"] = message.message_id
+    if bot_last_message_id:
+        try:
+            previous_state = context.user_data.get("previous_state")
+
+            await context.bot.edit_message_text(
+                ANSWER_TO_USER_MESSAGE,
+                chat_id=update.effective_chat.id,
+                message_id=bot_last_message_id,
+                reply_markup=get_back_keyboard(previous_state),
+            )
+        except Exception as e:
+            logger.error(f"Failed to edit message: {e}")
+
+    context.user_data["last_bot_message_id"] = bot_last_message_id
 
 
-# Определяем хендлер ответа на сообщения пользователя
 answer_all_messages_handler = MessageHandler(filters.ALL, answer_all_messages)

--- a/src/bot/keyboards/get_back.py
+++ b/src/bot/keyboards/get_back.py
@@ -1,0 +1,11 @@
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+from bot.constants.buttons import BACK_BUTTON
+
+
+def get_back_keyboard() -> InlineKeyboardMarkup:
+    """Клавиатура кнопки назад."""
+    back_button_inline_keyboard = [
+        [InlineKeyboardButton(BACK_BUTTON, callback_data="back")]
+    ]
+    return InlineKeyboardMarkup(back_button_inline_keyboard)

--- a/src/bot/keyboards/get_back.py
+++ b/src/bot/keyboards/get_back.py
@@ -1,18 +1,15 @@
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 from bot.constants.buttons import BACK_BUTTON
-from bot.constants.states.main_states import States
 
 
-def get_back_keyboard() -> InlineKeyboardMarkup:
-    """Клавиатура кнопки назад."""
-    return InlineKeyboardMarkup(
+def get_back_keyboard(previous_state=None) -> InlineKeyboardMarkup:
+    """Build the inline keyboard with a 'Back' button."""
+    back_button_inline_keyboard = [
         [
-            [
-                InlineKeyboardButton(
-                    text=BACK_BUTTON,
-                    callback_data=f"back_to_{States.ASSISTANCE.value}",
-                )
-            ],
+            InlineKeyboardButton(
+                BACK_BUTTON, callback_data=f"back_to_{previous_state}"
+            )
         ]
-    )
+    ]
+    return InlineKeyboardMarkup(back_button_inline_keyboard)

--- a/src/bot/keyboards/get_back.py
+++ b/src/bot/keyboards/get_back.py
@@ -1,11 +1,18 @@
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 from bot.constants.buttons import BACK_BUTTON
+from bot.constants.states.main_states import States
 
 
 def get_back_keyboard() -> InlineKeyboardMarkup:
     """Клавиатура кнопки назад."""
-    back_button_inline_keyboard = [
-        [InlineKeyboardButton(BACK_BUTTON, callback_data="back")]
-    ]
-    return InlineKeyboardMarkup(back_button_inline_keyboard)
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton(
+                    text=BACK_BUTTON,
+                    callback_data=f"back_to_{States.ASSISTANCE.value}",
+                )
+            ],
+        ]
+    )


### PR DESCRIPTION
На текущий момент, хендлер умеет удалять последнее сообщение пользователя и изменяет прошлое сообщение на "ANSWER_TO_USER_MESSAGE" с инлайн кнопкой назад. Кнопка работает, но с отклонениями от желаемого состояния:

1. Кнопка отправляет на статичное, а не на прошлое состояние бота;
2. Кнопка не работает при вызове более 1 раза в рамках одной сессии (без сброса состояния бота)