### PR TITLE
Автоматизировал развертку бота для локальной разработки

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,60 @@
-# for start mySQL container:
+## for start mySQL container:
+SHELL := /bin/bash
+LOCAL_COMPOSE_FILE := infra/dev/docker-compose.local.yaml
+
+COLOR_RESET = \033[0m
+COLOR_GREEN = \033[32m
+COLOR_YELLOW = \033[33m
+
+runbot-init: deletedb rundb migrate filldb runbot-db
+	@echo -e "$(COLOR_YELLOW)Starting initialization...$(COLOR_RESET)"
+
 rundb:
-	docker compose -f infra/dev/docker-compose.local.yaml up -d
+	@echo -e "$(COLOR_YELLOW)Starting database...$(COLOR_RESET)"
+	@docker compose -f $(LOCAL_COMPOSE_FILE) up -d
+	@echo -e "$(COLOR_GREEN)Database started$(COLOR_RESET)"
 
 # for stop mySQL container:
 stopdb:
-	docker compose -f infra/dev/docker-compose.local.yaml down
+	@echo -e "$(COLOR_YELLOW)Stopping database...$(COLOR_RESET)"
+	@docker compose -f $(LOCAL_COMPOSE_FILE) down
+	@echo -e "$(COLOR_GREEN)Database stopped$(COLOR_RESET)"
 
 # for stop mySQL container and delete database:
 deletedb:
-	docker compose -f infra/dev/docker-compose.local.yaml down --volumes
+	@echo -e "$(COLOR_YELLOW)Deleting database...$(COLOR_RESET)"
+	@docker compose -f $(LOCAL_COMPOSE_FILE) down --volumes
+	@echo -e "$(COLOR_GREEN)Database deleted$(COLOR_RESET)"
 
 # for start bot with Database container:
 runbot-db:
-	docker compose -f infra/dev/docker-compose.local.yaml up -d
-	cd src && poetry run uvicorn config.asgi:application --reload && cd ..
+	@echo -e "$(COLOR_YELLOW)Starting bot...$(COLOR_RESET)"
+	@docker compose -f $(LOCAL_COMPOSE_FILE) up -d
+	@cd src && poetry run uvicorn config.asgi:application --reload && cd .. && \
+	echo -e "$(COLOR_GREEN)Bot stopped$(COLOR_RESET)"
 
 filldb:
-	python src/manage.py filldb
+	@echo -e "$(COLOR_YELLOW)Filing database...$(COLOR_RESET)"
+	@until python src/manage.py filldb; do \
+	  echo -e "$(COLOR_YELLOW)Waiting database to be filled...$(COLOR_RESET)"; \
+	  sleep 5 ;\
+	done
+	@echo -e "$(COLOR_GREEN)Database filled$(COLOR_RESET)"
+
 
 collectstatic:
-	python src/manage.py collectstatic
+	@echo -e "$(COLOR_YELLOW)Collecting static...$(COLOR_RESET)"
+	@until python src/manage.py collectstatic; do \
+	  echo -e "$(COLOR_YELLOW)Waiting static to be collected...$(COLOR_RESET)"; \
+	  sleep 5 ;\
+	done
+	@echo -e "$(COLOR_GREEN)Static collected$(COLOR_RESET)"
+
 
 migrate:
-	python src/manage.py migrate
+	@echo -e "$(COLOR_YELLOW)Migrating...$(COLOR_RESET)"
+	@until python src/manage.py migrate; do \
+	  echo "Waiting for migrations..."; \
+	  sleep 5; \
+	done
+	@echo -e "$(COLOR_GREEN)Migrated$(COLOR_RESET)"

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,14 @@ LOCAL_COMPOSE_FILE := infra/dev/docker-compose.local.yaml
 COLOR_RESET = \033[0m
 COLOR_GREEN = \033[32m
 COLOR_YELLOW = \033[33m
+COLOR_WHITE = \033[00m
 
 .DEFAULT_GOAL := help
 .PHONY: help
 
 help:  # Show help
-	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
+	@echo -e "$(COLOR_GREEN)Makefile help:"
+	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | sort | while read -r l; do printf "$(COLOR_GREEN)-$$(echo $$l | cut -f 1 -d':'):$(COLOR_WHITE)$$(echo $$l | cut -f 2- -d'#')\n"; done
 
 .PHONY: runbot-init
 runbot-init: deletedb rundb migrate filldb runbot-db
@@ -35,7 +37,7 @@ stopdb: # Stop mySQL Database Docker-image
 
 
 .PHONY: deletedb
-deletedb: ## Stop and delete mySQL database Docker-image and volumes
+deletedb: # Stop and delete mySQL database Docker-image and volumes
 	@echo -e "$(COLOR_YELLOW)Deleting database...$(COLOR_RESET)"
 	@until docker compose -f $(LOCAL_COMPOSE_FILE) down --volumes; do \
 	  echo -e "$(COLOR_YELLOW)Waiting database to be deleted...$(COLOR_RESET)"; \

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ runbot-init: deletedb rundb migrate filldb runbot-db
 
 rundb:
 	@echo -e "$(COLOR_YELLOW)Starting database...$(COLOR_RESET)"
-	@docker compose -f $(LOCAL_COMPOSE_FILE) up -d
+	@until docker compose -f $(LOCAL_COMPOSE_FILE) up -d; do \
+	  echo -e "$(COLOR_YELLOW)Waiting database to be started...$(COLOR_RESET)"; \
+	  sleep 5 ;\
+	done
 	@echo -e "$(COLOR_GREEN)Database started$(COLOR_RESET)"
 
 # for stop mySQL container:
@@ -23,7 +26,10 @@ stopdb:
 # for stop mySQL container and delete database:
 deletedb:
 	@echo -e "$(COLOR_YELLOW)Deleting database...$(COLOR_RESET)"
-	@docker compose -f $(LOCAL_COMPOSE_FILE) down --volumes
+	@until docker compose -f $(LOCAL_COMPOSE_FILE) down --volumes; do \
+	  echo -e "$(COLOR_YELLOW)Waiting database to be deleted...$(COLOR_RESET)"; \
+	  sleep 5 ;\
+	done
 	@echo -e "$(COLOR_GREEN)Database deleted$(COLOR_RESET)"
 
 # for start bot with Database container:

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,18 @@ COLOR_RESET = \033[0m
 COLOR_GREEN = \033[32m
 COLOR_YELLOW = \033[33m
 
+.DEFAULT_GOAL := help
+.PHONY: help
+
+help:  # Show help
+	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
+
+.PHONY: runbot-init
 runbot-init: deletedb rundb migrate filldb runbot-db
 	@echo -e "$(COLOR_YELLOW)Starting initialization...$(COLOR_RESET)"
 
-rundb:
+.PHONY: rundb
+rundb: # Build and run Database Docker-image
 	@echo -e "$(COLOR_YELLOW)Starting database...$(COLOR_RESET)"
 	@until docker compose -f $(LOCAL_COMPOSE_FILE) up -d; do \
 	  echo -e "$(COLOR_YELLOW)Waiting database to be started...$(COLOR_RESET)"; \
@@ -18,14 +26,16 @@ rundb:
 	@sleep 3 ;
 	@echo -e "$(COLOR_GREEN)Database started$(COLOR_RESET)"
 
-# for stop mySQL container:
-stopdb:
+
+.PHONY: stopdb
+stopdb: # Stop mySQL Database Docker-image
 	@echo -e "$(COLOR_YELLOW)Stopping database...$(COLOR_RESET)"
 	@docker compose -f $(LOCAL_COMPOSE_FILE) down
 	@echo -e "$(COLOR_GREEN)Database stopped$(COLOR_RESET)"
 
-# for stop mySQL container and delete database:
-deletedb:
+
+.PHONY: deletedb
+deletedb: ## Stop and delete mySQL database Docker-image and volumes
 	@echo -e "$(COLOR_YELLOW)Deleting database...$(COLOR_RESET)"
 	@until docker compose -f $(LOCAL_COMPOSE_FILE) down --volumes; do \
 	  echo -e "$(COLOR_YELLOW)Waiting database to be deleted...$(COLOR_RESET)"; \
@@ -34,14 +44,15 @@ deletedb:
 	@sleep 3 ;
 	@echo -e "$(COLOR_GREEN)Database deleted$(COLOR_RESET)"
 
-# for start bot with Database container:
-runbot-db:
+
+.PHONY: runbot-db
+runbot-db: # Run Telegram bot on Uvicorn
 	@echo -e "$(COLOR_YELLOW)Starting bot...$(COLOR_RESET)"
-	@docker compose -f $(LOCAL_COMPOSE_FILE) up -d
 	@cd src && poetry run uvicorn config.asgi:application --reload && cd .. && \
 	echo -e "$(COLOR_GREEN)Bot stopped$(COLOR_RESET)"
 
-filldb:
+.PHONY: filldb
+filldb: # Fill Docker-image Database with test data
 	@echo -e "$(COLOR_YELLOW)Filing database...$(COLOR_RESET)"
 	@until python src/manage.py filldb; do \
 	  echo -e "$(COLOR_YELLOW)Waiting database to be filled...$(COLOR_RESET)"; \
@@ -50,8 +61,8 @@ filldb:
 	@sleep 3 ;
 	@echo -e "$(COLOR_GREEN)Database filled$(COLOR_RESET)"
 
-
-collectstatic:
+.PHONY: collectstatic
+collectstatic: # Collect project static files
 	@echo -e "$(COLOR_YELLOW)Collecting static...$(COLOR_RESET)"
 	@until python src/manage.py collectstatic; do \
 	  echo -e "$(COLOR_YELLOW)Waiting static to be collected...$(COLOR_RESET)"; \
@@ -60,8 +71,8 @@ collectstatic:
 	@sleep 3;
 	@echo -e "$(COLOR_GREEN)Static collected$(COLOR_RESET)"
 
-
-migrate:
+.PHONY: migrate
+migrate: # Commit migrations to Database
 	@echo -e "$(COLOR_YELLOW)Migrating...$(COLOR_RESET)"
 	@until python src/manage.py migrate; do \
 	  echo "Waiting for migrations..."; \

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ rundb:
 	  echo -e "$(COLOR_YELLOW)Waiting database to be started...$(COLOR_RESET)"; \
 	  sleep 5 ;\
 	done
+	@sleep 3 ;
 	@echo -e "$(COLOR_GREEN)Database started$(COLOR_RESET)"
 
 # for stop mySQL container:
@@ -30,6 +31,7 @@ deletedb:
 	  echo -e "$(COLOR_YELLOW)Waiting database to be deleted...$(COLOR_RESET)"; \
 	  sleep 5 ;\
 	done
+	@sleep 3 ;
 	@echo -e "$(COLOR_GREEN)Database deleted$(COLOR_RESET)"
 
 # for start bot with Database container:
@@ -45,6 +47,7 @@ filldb:
 	  echo -e "$(COLOR_YELLOW)Waiting database to be filled...$(COLOR_RESET)"; \
 	  sleep 5 ;\
 	done
+	@sleep 3 ;
 	@echo -e "$(COLOR_GREEN)Database filled$(COLOR_RESET)"
 
 
@@ -54,6 +57,7 @@ collectstatic:
 	  echo -e "$(COLOR_YELLOW)Waiting static to be collected...$(COLOR_RESET)"; \
 	  sleep 5 ;\
 	done
+	@sleep 3;
 	@echo -e "$(COLOR_GREEN)Static collected$(COLOR_RESET)"
 
 
@@ -63,4 +67,5 @@ migrate:
 	  echo "Waiting for migrations..."; \
 	  sleep 5; \
 	done
+	@sleep 3;
 	@echo -e "$(COLOR_GREEN)Migrated$(COLOR_RESET)"


### PR DESCRIPTION
* Установил оболочку /bin/bash;
* Вынес в константы расположение файла docker-compose.local.yaml;
* Добавил форматированный вывод в консоль;
* Добавил команду runbot-init, автоматизирующую равзвертывание бота для локальной обработки. Команда последовательно запускает перезапуск БД (deletedb, rundb), применяет миграции (migrate), наполняет БД стартовыми данными (filldb), запускает бота (runbot-db).
