### PR TITLE
add nginx configuration for serving static

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ local_settings.py
 db.sqlite3
 db.sqlite3-journal
 static/
+media/
 
 # Flask stuff:
 instance/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN pip install -r ./requirements/develop.txt
 
 WORKDIR ./src
 
-CMD [ "uvicorn", "config.asgi:application" ]
+CMD [ "uvicorn", "config.asgi:application", "--host", "0.0.0.0", "--port", "8000" ]

--- a/infra/dev/docker-compose.stage.yaml
+++ b/infra/dev/docker-compose.stage.yaml
@@ -37,15 +37,6 @@ services:
     networks:
       - spread-wings-network
 
-#    find out how to implement properly. Currently does not work, error occures
-#    "You're using the staticfiles app without having set the STATIC_ROOT setting to a filesystem path"
-#    command: >
-#      bash -c "
-#        python manage.py migrate &&
-#        python manage.py collectstatic --noinput &&
-#        python manage.py createsuperuser --email example@yandex.ru --noinput
-#      "
-
   bot:
     image: "ghcr.io/studio-yandex-practicum/spread_wings_bot:develop"
     container_name: spread-wings-bot
@@ -58,17 +49,53 @@ services:
     networks:
       - spread-wings-network
 
+  mysql:
+    image: mysql:8.0
+    container_name: spread-wings-mysql
+    restart: always
+    env_file: /home/spread_wings/site/.env
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    ports:
+      - "3306:3306"
+    volumes:
+      - /home/spread_wings/site/krilya_dets1_local.sql.gz:/docker-entrypoint-initdb.d/backup.sql.gz
+      - /home/spread_wings/site/migrate_server.sql:/docker-entrypoint-initdb.d/migrate.sql
+    networks:
+      - spread-wings-network
+
+  wordpress:
+    image: wordpress:5.8.1-php7.4-apache
+    container_name: spread-wings-wordpress
+    volumes:
+      - /home/spread_wings/site/public_html:/var/www/html
+    restart: always
+    env_file: /home/spread_wings/site/.env
+    depends_on:
+      - mysql
+    environment:
+      WORDPRESS_DB_HOST: spread-wings-mysql:3306
+      WORDPRESS_DB_NAME: ${WORDPRESS_DB_NAME}
+      WORDPRESS_DB_USER: ${WORDPRESS_DB_USER}
+      WORDPRESS_DB_PASSWORD: ${WORDPRESS_DB_PASSWORD}
+    networks:
+      - spread-wings-network
+
   nginx:
     image: nginx:1.21.3-alpine
     container_name: spread-wings-nginx
     ports:
-      - "8001:80"
+      - "80:80"
     volumes:
       - ./nginx.stage.conf:/etc/nginx/conf.d/default.conf
       - ../../src/static:/var/html/static/
       - ../../src/media:/var/html/media/
     depends_on:
       - bot
+      - wordpress
     restart: always
     networks:
       - spread-wings-network

--- a/infra/dev/docker-compose.stage.yaml
+++ b/infra/dev/docker-compose.stage.yaml
@@ -1,16 +1,26 @@
 version: '3.8'
+name: spread-wings-stage
 
 services:
 
   redis:
     image: redis:latest
+    container_name: spread-wings-redis
     ports:
       - "6379:6379"
     restart: always
-    command: bash -c " mkdir /data/log -p && mkdir /data/bases -p && touch /data/log/redis-server.log && redis-server /usr/local/etc/redis.conf "
+    command: > 
+      bash -c "
+        mkdir /data/log -p &&
+        mkdir /data/bases -p &&
+        touch /data/log/redis-server.log &&
+        redis-server /usr/local/etc/redis.conf | tee -a /data/log/redis-server.log
+      "
     volumes:
       - ./redis.conf:/usr/local/etc/redis.conf
       - data_value:/data
+    networks:
+      - spread-wings-network
 
   db:
     image: postgres:15.3-alpine
@@ -24,31 +34,50 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
     restart: always
+    networks:
+      - spread-wings-network
+
+#    find out how to implement properly. Currently does not work, error occures
+#    "You're using the staticfiles app without having set the STATIC_ROOT setting to a filesystem path"
+#    command: >
+#      bash -c "
+#        python manage.py migrate &&
+#        python manage.py collectstatic --noinput &&
+#        python manage.py createsuperuser --email example@yandex.ru --noinput
+#      "
 
   bot:
     image: "ghcr.io/studio-yandex-practicum/spread_wings_bot:develop"
+    container_name: spread-wings-bot
     depends_on:
       - redis
       - db
     restart: always
     env_file:
       - ./.env
+    networks:
+      - spread-wings-network
 
-  django_commands:
-    image: "ghcr.io/studio-yandex-practicum/spread_wings_bot:develop"
+  nginx:
+    image: nginx:1.21.3-alpine
+    container_name: spread-wings-nginx
+    ports:
+      - "8001:80"
+    volumes:
+      - ./nginx.stage.conf:/etc/nginx/conf.d/default.conf
+      - ../../src/static:/var/html/static/
+      - ../../src/media:/var/html/media/
     depends_on:
-      - redis
-      - db
       - bot
-    env_file:
-      - ./.env
-    command: >
-      bash -c "
-        python manage.py migrate &&
-        python manage.py collectstatic --noinput &&
-        python manage.py createsuperuser --email example@yandex.ru --noinput
-      "
+    restart: always
+    networks:
+      - spread-wings-network
 
 volumes:
   data_value:
   db_data:
+  static:
+  media:
+
+networks:
+  spread-wings-network:

--- a/infra/dev/nginx.stage.conf
+++ b/infra/dev/nginx.stage.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+
+    server_name 127.0.0.1;
+
+    location /static/ {
+        root /var/html/;
+    }
+
+    location /media/ {
+        root /var/html/;
+    }
+
+    location / {
+        proxy_pass http://spread-wings-bot:8000;
+        proxy_set_header        Host $host;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+    }
+
+    error_page 500 502 503 504  /50x.html;
+
+    location = /50x.html {
+        root /usr/share/nginx/html/50x.html;
+    }
+}

--- a/infra/dev/nginx.stage.conf
+++ b/infra/dev/nginx.stage.conf
@@ -1,7 +1,7 @@
 server {
     listen 80;
 
-    server_name 127.0.0.1;
+    server_name 51.250.73.184;
 
     location /static/ {
         root /var/html/;
@@ -11,8 +11,16 @@ server {
         root /var/html/;
     }
 
+    location /django/ {
+        proxy_pass              http://spread-wings-bot:8000;
+        proxy_set_header        Host $host;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+    }
+
     location / {
-        proxy_pass http://spread-wings-bot:8000;
+        proxy_pass              http://spread-wings-wordpress;
         proxy_set_header        Host $host;
         proxy_set_header        X-Real-IP $remote_addr;
         proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/infra/dev/redis.conf
+++ b/infra/dev/redis.conf
@@ -6,7 +6,7 @@ timeout 0
 tcp-keepalive 300
 pidfile /var/run/redis/redis-server.pid
 loglevel notice
-logfile /data/log/redis-server.log
+logfile ""
 databases 16
 always-show-logo yes
 save 900 1

--- a/infra/init.sh
+++ b/infra/init.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+docker-compose run bot python manage.py migrate
+docker-compose run bot python manage.py collectstatic --noinput
+docker-compose run bot python manage.py createsuperuser --email example@yandex.ru --noinput

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -4,9 +4,11 @@ from django.contrib import admin
 from django.urls import include, path
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
-    path("users/", include("users.urls"), name="users"),
-    path("bot/", include("bot.urls"), name="bot"),
+    path("django/", include([
+        path("admin/", admin.site.urls),
+        path("users/", include("users.urls"), name="users"),
+        path("bot/", include("bot.urls"), name="bot"),
+    ])),
 ]
 
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
closes #113 
---

- create nginx config
- update redis config (logs are visible in console)
- change root url for django app in order to force nginx manage requests between two apps properly. Django ulrs now have `/django` prefix
- move initial commands from container to init.sh script (migrate, collectstatic, createsuperuser)
- merge bot app and wordpress app into one docker compose file
- add "media" to gitignore
